### PR TITLE
Fix BatteryLevel enum

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -38,7 +38,7 @@ pub enum BatteryLevel {
     None = 1,
     Low = 3,
     Critical = 4,
-    Normal = 5,
+    Normal = 6,
     High = 7,
     Full = 8,
 }


### PR DESCRIPTION
According to the [UPower D-Bus docs](https://upower.freedesktop.org/docs/Device.html), the Normal state is number 6, not 5